### PR TITLE
Add a hook for CallRecorder.canRecordInCurrentCountry

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 		/* for Context.MODE_WORLD_READABLE */
 		targetSdkVersion 23
 		versionCode 13
-		versionName "1.0.13"
+		versionName "1.0.14"
 	}
 
 	signingConfigs {


### PR DESCRIPTION
Call recording was [changed in November](https://review.lineageos.org/c/LineageOS/android_packages_apps_Dialer/+/264188) to use the current country code, breaking this module. I'm not too familiar with the Xposed framework but hooking this new method fixes things for me.